### PR TITLE
init fabric with none loggers

### DIFF
--- a/utils/initialization.py
+++ b/utils/initialization.py
@@ -84,7 +84,7 @@ def initialize_fabric(training_config: TrainingConfig, experiment_tracker: Optio
         precision=training_config.fabric.precision,
         devices=training_config.fabric.num_devices,
         num_nodes=training_config.fabric.num_nodes,
-        loggers=[experiment_tracker]
+        loggers=[experiment_tracker] if experiment_tracker is not None else None
     )
 
     fabric.launch()


### PR DESCRIPTION
fabric was initalised improperly if no logger is set (i.e. experiment_tracker set to null/None in config)
- this led to runtime error of `AttributeError: 'NoneType' object has no attribute 'log_metrics'` thrown from fabric