### PR TITLE
fix datasets package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ lightning = "^2.4.0"
 click = "^8.1.7"
 wandb = "^0.18.1"
 huggingface-hub = {extras = ["cli"], version = "^0.25.1"}
-datasets = "^3.0.1"
+datasets = "^3.0.1,<3.2.0"
 transformers = "^4.45.2"
 pre-commit = "^4.0.1"
 torch = "^2.5.1"


### PR DESCRIPTION
Package `datasets` at version `== 3.2.0` was causing an obscure error where training code would complete and then hang indefinitely until manually ended with `ctrl+c`. This does not happen in version 3.1.0, so I added a version constraint in the pyproject.toml.

