### PR TITLE
Quicker Fast Forwarding

### DIFF
--- a/src/training/utils/data.py
+++ b/src/training/utils/data.py
@@ -3,7 +3,6 @@ Utilities for data loading and processing.
 """
 
 from torch.utils.data import IterableDataset
-from datasets import load_dataset
 
 
 class ShardedIterableDataset(IterableDataset):
@@ -34,19 +33,3 @@ class ShardedIterableDataset(IterableDataset):
                     next(iterator)
             except StopIteration:
                 break
-
-
-def load_sharded_dataset(
-    dataset_name: str, initial_batch_step: int, batches_per_shard: int
-) -> IterableDataset:
-    """
-    Load a sharded dataset for a given global step.
-    """
-
-    shard_idx = initial_batch_step // batches_per_shard
-    valid_files = [
-        f"train-{_shard_idx}-of-10000.parquet" for _shard_idx in range(shard_idx, 10000)
-    ]
-    return load_dataset(
-        dataset_name, split="train", streaming=True, data_files=valid_files
-    )

--- a/src/training/utils/data.py
+++ b/src/training/utils/data.py
@@ -1,0 +1,52 @@
+"""
+Utilities for data loading and processing.
+"""
+
+from torch.utils.data import IterableDataset
+from datasets import load_dataset
+
+
+class ShardedIterableDataset(IterableDataset):
+    """
+    A super simple implementation of a sharded iterable dataset that enables DataParallelism
+    across multiple workers. Ensures that each worker gets a unique shard of the dataset.
+
+    NOTE: Also works fine if there is only one worker.
+    """
+
+    def __init__(self, dataset, rank, world_size):
+        self.dataset = dataset
+        self.rank = rank
+        self.world_size = world_size
+
+    def __iter__(self):
+        iterator = iter(self.dataset)
+        # NOTE: Start by skipping to this worker's shard
+        for _ in range(self.rank):
+            next(iterator)
+
+        # NOTE: Yield every world_size-th item
+        while True:
+            try:
+                yield next(iterator)
+                # Skip other workers' samples
+                for _ in range(self.world_size - 1):
+                    next(iterator)
+            except StopIteration:
+                break
+
+
+def load_sharded_dataset(
+    dataset_name: str, initial_batch_step: int, batches_per_shard: int
+) -> IterableDataset:
+    """
+    Load a sharded dataset for a given global step.
+    """
+
+    shard_idx = initial_batch_step // batches_per_shard
+    valid_files = [
+        f"train-{_shard_idx}-of-10000.parquet" for _shard_idx in range(shard_idx, 10000)
+    ]
+    return load_dataset(
+        dataset_name, split="train", streaming=True, data_files=valid_files
+    )

--- a/src/training/utils/initialization.py
+++ b/src/training/utils/initialization.py
@@ -19,7 +19,7 @@ from datetime import datetime
 import wandb
 from huggingface_hub import create_repo, create_branch
 from wandb.integration.lightning.fabric import WandbLogger
-from datasets import load_dataset, Dataset
+from datasets import load_dataset, Dataset, DownloadConfig
 from torch.utils.data import DataLoader
 from transformers import AutoTokenizer
 from typing import Optional, Dict, Union
@@ -244,6 +244,10 @@ def initialize_dataset(
         Optional[int]: Number of steps to fast-forward the iterator by, if return_fast_forward_steps is True.
     """
 
+    download_config = DownloadConfig(
+        max_retries=10,  # default is 1 and can lead to pre-mature HTTPS errors
+    )
+
     fast_forward_steps = 0
 
     if data_config.dataset.name == "pico-lm/pretokenized-dolma":
@@ -271,13 +275,17 @@ def initialize_dataset(
             split="train",
             streaming=True,
             data_files=data_files,
+            download_config=download_config,
         )
     else:
         # NOTE: For other datasets, you might want to add some custom loading logic, especially
         # to help with loading or fast-forwarding to the correct batch.
 
         base_dataset = load_dataset(
-            data_config.dataset.name, split="train", streaming=True
+            data_config.dataset.name,
+            split="train",
+            streaming=True,
+            download_config=download_config,
         )
 
     if data_config.dataset.name == "pico-lm/pretokenized-dolma":


### PR DESCRIPTION
The new dataset is sharded into 10,000 shards - this new PR provides a way of quickly fast-forwarding the dataloader when we resume from a checkpoint by selectively only downloading files beginning with the file that contains the data at the chekpointed batch step. 

At most the dataloader will only have to fast-forward through 20 batches of size 1024. 