### PR TITLE
Bug Fix: Freqs Cis Grad Flow

### DIFF
--- a/src/model/pico.py
+++ b/src/model/pico.py
@@ -148,6 +148,7 @@ class RoPE(nn.Module):
         freqs = torch.outer(positions, _freqs)
         return torch.polar(torch.ones_like(freqs), freqs)  # complex64
 
+    @torch.no_grad()
     def get_freqs_cis(
         self, input_shape: torch.Size, start_pos: int, end_pos: int
     ) -> torch.Tensor:
@@ -164,7 +165,6 @@ class RoPE(nn.Module):
         shape = [d if i == 1 or i == ndim - 1 else 1 for i, d in enumerate(input_shape)]
         return _freqs_cis.view(*shape)
 
-    @torch.no_grad()
     def forward(
         self,
         queries: torch.Tensor,


### PR DESCRIPTION
I think that the torch no grad has to ONLY prevent the freqs_cis tensor from being learned - if we stop the grad at ROPE the grad doesn't flow back to the linear operation in the Attention module. 