### PR TITLE
freqs cis as buffer

### DIFF
--- a/src/checkpointing/learning_dynamics.py
+++ b/src/checkpointing/learning_dynamics.py
@@ -278,7 +278,7 @@ def compute_learning_dynamics_states(
     )
 
     # Create a new model instance with same parameters but zero gradients
-    _model = Pico(model.config, fabric=fabric)
+    _model = Pico(model.config)
     _model.load_state_dict(model.state_dict())
 
     if isinstance(fabric.strategy, DeepSpeedStrategy):

--- a/src/model/pico.py
+++ b/src/model/pico.py
@@ -312,7 +312,7 @@ class Attention(nn.Module):
 
         backends = [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]
 
-        with sdpa_kernel(backends=backends, set_priority=True):
+        with sdpa_kernel(backends=backends):
             attn_output = F.scaled_dot_product_attention(
                 queries.contiguous(),
                 keys.contiguous(),

--- a/src/model/pico.py
+++ b/src/model/pico.py
@@ -301,13 +301,9 @@ class Attention(nn.Module):
         keys = keys.transpose(1, 2)
         values = values.transpose(1, 2)
 
-        # see if cuda available
-        if torch.cuda.is_available():
-            backend = SDPBackend.CUDNN_ATTENTION
-        else:
-            backend = SDPBackend.MATH
+        backends = [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]
 
-        with sdpa_kernel(backends=[backend]):
+        with sdpa_kernel(backends=backends, set_priority=True):
             attn_output = F.scaled_dot_product_attention(
                 queries.contiguous(),
                 keys.contiguous(),

--- a/src/model/pico.py
+++ b/src/model/pico.py
@@ -297,18 +297,18 @@ class Attention(nn.Module):
             cached_keys = None
             cached_values = None
 
+        queries = queries.transpose(1, 2)
+        keys = keys.transpose(1, 2)
+        values = values.transpose(1, 2)
+
         apply_gqa = self.n_rep > 1
         if apply_gqa and queries.device.type == "mps":
             # NOTE: MPS does not support GQA in the SDPA kernel, but we can repeat the keys and values
             # outside of the kernel to get the same effect.
-            # See: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html?utm_source=chatgpt.com
-            keys = keys.repeat_interleave(self.n_rep, dim=2)
-            values = values.repeat_interleave(self.n_rep, dim=2)
+            # See: https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+            keys = keys.repeat_interleave(self.n_rep, dim=-3)
+            values = values.repeat_interleave(self.n_rep, dim=-3)
             apply_gqa = False
-
-        queries = queries.transpose(1, 2)
-        keys = keys.transpose(1, 2)
-        values = values.transpose(1, 2)
 
         backends = [SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]
 

--- a/src/model/pico.py
+++ b/src/model/pico.py
@@ -496,7 +496,7 @@ class Pico(nn.Module):
                 # Add zeros for cached tokens (we can attend to all of them)
                 mask = torch.hstack([torch.zeros((seq_len, start_pos)), mask])
 
-            mask = mask.to(h.dtype)
+            mask = mask.to(h.device)
 
         # NOTE: If we are using the cache, we need to store the cached KV pairs for each layer
         #       in a tuple. Each layer will have its own cached KV pair which we aggregate in a tuple.

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -98,7 +98,7 @@ class Trainer:
         )
 
         # Setup Model, Optimizer, and Dataloaders
-        self.model = Pico(model_config=self.configs["model"], fabric=self.fabric)
+        self.model = Pico(model_config=self.configs["model"])
         self.optimizer = initialize_optimizer(
             training_config=self.configs["training"], model=self.model
         )


### PR DESCRIPTION
- use a shared `_freqs_cis_tensor` across all `RoPE` class instances
- each `RoPE` instance has its own registered buffer `_freqs_cis`
- this also means device moving is handled automatically (which is nice)
- deprecates need to initialise `RoPE` with a `fabric` instance, so this was removed 
- this means that fabric does not need to be fed all the way through to pico any more