### PR TITLE
Making batch size smaller of small/medium models

### DIFF
--- a/configs/pico-medium.yaml
+++ b/configs/pico-medium.yaml
@@ -7,7 +7,7 @@ checkpointing:
   save_checkpoint_repo_id: "pico-lm/pico-medium"
 
   learning_dynamics:
-    batch_size: 256
+    batch_size: 128
 
 model:
     d_model: 768
@@ -15,7 +15,7 @@ model:
 
 training:
   optimization:
-    gradient_accumulation_steps: 4
+    gradient_accumulation_steps: 8
   
   fabric:
     num_nodes: 4
@@ -23,5 +23,5 @@ training:
   
 evaluation: 
   paloma:
-    batch_size: 32
+    batch_size: 16
   

--- a/configs/pico-small.yaml
+++ b/configs/pico-small.yaml
@@ -7,7 +7,7 @@ checkpointing:
   save_checkpoint_repo_id: "pico-lm/pico-small"
 
   learning_dynamics:
-    batch_size: 256
+    batch_size: 128
 
 model:
     d_model: 384
@@ -15,7 +15,7 @@ model:
 
 training:
   optimization:
-    gradient_accumulation_steps: 4
+    gradient_accumulation_steps: 8
   
   fabric:
     num_nodes: 4
@@ -23,5 +23,5 @@ training:
   
 evaluation: 
   paloma:
-    batch_size: 32
+    batch_size: 16
   


### PR DESCRIPTION
To be on the safe side during training, reducing the batch size of the small and medium models by 1/2 (to 8 from 16). 