### PR TITLE
Make Pico Model be Pico Decoder

### DIFF
--- a/src/checkpointing/learning_dynamics.py
+++ b/src/checkpointing/learning_dynamics.py
@@ -14,8 +14,7 @@ from huggingface_hub import upload_folder
 
 import deepspeed
 
-from src.model import Pico
-
+from src.training.utils.initialization import initialize_model
 from src.training.utils.io import use_backoff
 
 # typing imports
@@ -285,7 +284,7 @@ def compute_learning_dynamics_states(
     )
 
     # Create a new model instance with same parameters but zero gradients
-    _model = Pico(model.config)
+    _model = initialize_model(model.config)
     _model.load_state_dict(model.state_dict())
 
     if isinstance(fabric.strategy, DeepSpeedStrategy):

--- a/src/config/model_config.py
+++ b/src/config/model_config.py
@@ -12,6 +12,10 @@ from ._constants import VOCAB_SIZE, BATCH_SIZE, MAX_SEQ_LEN
 
 @dataclass
 class ModelConfig:
+    model_type: str = "pico_decoder"
+
+    # Pico Decoder Defaults
+
     d_model: int = 768
     n_layers: int = 12
 

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,10 +1,12 @@
 """
 Model Package
 
-This Package contains the Pico model. If you have other models you'd like to implement, we
-recommend you add modules to this package.
+This Package contains Pico models (currently only the Pico Decoder). We plan to implement other
+architectures in the future.
+
+If you have other models you'd like to implement, we recommend you add modules to this package.
 """
 
 # ruff: noqa: F401
 
-from .pico import Pico
+from .pico_decoder import PicoDecoder

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -23,8 +23,6 @@ from lightning.fabric.utilities.rank_zero import rank_zero_only
 from datasets import Dataset, load_dataset
 from typing import Dict, Any
 
-from src.model import Pico
-
 from src.training.utils import (
     initialize_run_dir,
     initialize_fabric,
@@ -37,6 +35,7 @@ from src.training.utils import (
     initialize_experiment_tracker,
     initialize_logging,
     initialize_optimizer,
+    initialize_model,
 )
 from src.checkpointing import (
     load_checkpoint,
@@ -98,7 +97,7 @@ class Trainer:
         )
 
         # Setup Model, Optimizer, and Dataloaders
-        self.model = Pico(model_config=self.configs["model"])
+        self.model = initialize_model(model_config=self.configs["model"])
         self.optimizer = initialize_optimizer(
             training_config=self.configs["training"], model=self.model
         )

--- a/src/training/utils/__init__.py
+++ b/src/training/utils/__init__.py
@@ -16,4 +16,5 @@ from .initialization import (
     initialize_experiment_tracker,
     initialize_logging,
     initialize_optimizer,
+    initialize_model,
 )

--- a/src/training/utils/initialization.py
+++ b/src/training/utils/initialization.py
@@ -35,6 +35,8 @@ from src.config import (
     CheckpointingConfig,
 )
 
+from src.model import PicoDecoder
+
 from lightning.fabric.loggers import Logger as FabricLogger
 
 from src.training.utils.io import use_backoff
@@ -370,6 +372,35 @@ def initialize_dataloader(
         pin_memory=True,  # Speeds up transfer to GPU
         collate_fn=_collate_fn,
     )
+
+
+########################################################
+#
+# Model Initialization
+#
+########################################################
+
+
+def initialize_model(model_config: ModelConfig):
+    """Initialize the model for training.
+
+    Loads in a given model implemented in the `src.model` package and returns it.
+
+    NOTE: out of the box we currently only support the PicoDecoder model (a causal transformer
+    language model). If you'd like to implement your own model, you can do so by adding a new
+    model class in the `src.model` package, and then adding a new entry here.
+
+    Args:
+        model_config: Configuration object containing model settings.
+
+    Returns:
+        PyTorch model instance.
+
+    """
+    if model_config.model_type == "pico_decoder":
+        return PicoDecoder(model_config)
+    else:
+        raise ValueError(f"Invalid model type: {model_config.model_type}")
 
 
 ########################################################


### PR DESCRIPTION
I think we want to not hard-code the 'pico' model to be a llama-style model. I think it makes sense to call this auto-regressive transformer model just the pico-decoder model, and that leaves the opportunity for us to later implement other 'pico' models like 'pico-diffusion', 'pico-encoder', 'pico-statespace' etc. I guess the idea is that any pico-* model is a minimal and lightweight re-implementation of that model type that doesn't obscure any of the model logic behind random libraries