### PR TITLE
Simplifying Wandb and HF + Updating Pico Naming Convention

### DIFF
--- a/configs/demo.yaml
+++ b/configs/demo.yaml
@@ -7,10 +7,12 @@ data:
     batch_size: 32
   
 checkpointing:
-  run_name: "demo-1"
+  run_name: "pico-decoder-demo-1"
   save_every_n_steps: 50
 
-  save_checkpoint_repo_id: "pico-lm/demo"
+  save_to_hf: true
+  hf_checkpoint:
+    repo_id: "pico-lm/demo"
 
   learning_dynamics:
     batch_size: 16
@@ -24,6 +26,12 @@ evaluation:
     batch_size: 32
 
 monitoring:
+
+  save_to_wandb: true
+  wandb:
+    project: "pico-demo"
+    entity: "pico-lm"
+
   logging:
     log_every_n_steps: 10
 

--- a/configs/pico-large.yaml
+++ b/configs/pico-large.yaml
@@ -3,8 +3,10 @@
 # Refer to the config files in the configs/ directory to see all the available options
 
 checkpointing:
-  run_name: "pico-large-1"
-  save_checkpoint_repo_id: "pico-lm/pico-large"
+  run_name: "pico-decoder-large-1"
+  save_to_hf: true
+  hf_checkpoint:
+    repo_id: "pico-lm/pico-decoder-large"
 
   learning_dynamics:
     batch_size: 128
@@ -12,6 +14,12 @@ checkpointing:
 model:
     d_model: 1536
     activation_hidden_dim: 6144
+
+monitoring:
+  save_to_wandb: true
+  wandb:
+    project: "pico-decoder"
+    entity: "pico-lm"
 
 training:
   optimization:

--- a/configs/pico-medium.yaml
+++ b/configs/pico-medium.yaml
@@ -3,8 +3,10 @@
 # Refer to the config files in the configs/ directory to see all the available options
 
 checkpointing:
-  run_name: "pico-medium-1"
-  save_checkpoint_repo_id: "pico-lm/pico-medium"
+  run_name: "pico-decoder-medium-1"
+  save_to_hf: true
+  hf_checkpoint:
+    repo_id: "pico-lm/pico-decoder-medium"
 
   learning_dynamics:
     batch_size: 128
@@ -12,6 +14,12 @@ checkpointing:
 model:
     d_model: 768
     activation_hidden_dim: 3072
+
+monitoring:
+  save_to_wandb: true
+  wandb:
+    project: "pico-decoder"
+    entity: "pico-lm"
 
 training:
   optimization:

--- a/configs/pico-small.yaml
+++ b/configs/pico-small.yaml
@@ -3,8 +3,10 @@
 # Refer to the config files in the configs/ directory to see all the available options
 
 checkpointing:
-  run_name: "pico-small-1"
-  save_checkpoint_repo_id: "pico-lm/pico-small"
+  run_name: "pico-decoder-small-1"
+  save_to_hf: true
+  hf_checkpoint:
+    repo_id: "pico-lm/pico-decoder-small"
 
   learning_dynamics:
     batch_size: 128
@@ -12,6 +14,12 @@ checkpointing:
 model:
     d_model: 384
     activation_hidden_dim: 1536
+
+monitoring:
+  save_to_wandb: true
+  wandb:
+    project: "pico-decoder"
+    entity: "pico-lm"
 
 training:
   optimization:

--- a/configs/pico-tiny.yaml
+++ b/configs/pico-tiny.yaml
@@ -3,8 +3,10 @@
 # Refer to the config files in the configs/ directory to see all the available options
 
 checkpointing:
-  run_name: "pico-tiny-1"
-  save_checkpoint_repo_id: "pico-lm/pico-tiny"
+  run_name: "pico-decoder-tiny-1"
+  save_to_hf: true
+  hf_checkpoint:
+    repo_id: "pico-lm/pico-decoder-tiny"
 
   learning_dynamics:
     batch_size: 256
@@ -12,6 +14,12 @@ checkpointing:
 model:
     d_model: 96
     activation_hidden_dim: 384
+
+monitoring:
+  save_to_wandb: true
+  wandb:
+    project: "pico-decoder"
+    entity: "pico-lm"
 
 training:
   optimization:

--- a/src/checkpointing/evaluation.py
+++ b/src/checkpointing/evaluation.py
@@ -56,11 +56,11 @@ def save_evaluation_results(
     with open(curr_eval_results_path, "w") as f:
         json.dump(evaluation_results, f)
 
-    if checkpointing_config.save_checkpoint_repo_id is not None:
+    if checkpointing_config.save_to_hf:
         upload_folder(
             folder_path=eval_results_dir,
             path_in_repo=checkpointing_config.evaluation.eval_results_dir,
-            repo_id=checkpointing_config.save_checkpoint_repo_id,
+            repo_id=checkpointing_config.hf_checkpoint.repo_id,
             commit_message=f"Saving Evaluation Results -- Step {checkpoint_step}",
             revision=checkpointing_config.run_name,
             token=os.getenv("HF_TOKEN"),

--- a/src/checkpointing/learning_dynamics.py
+++ b/src/checkpointing/learning_dynamics.py
@@ -414,12 +414,12 @@ def save_learning_dynamics_states(
         )
         learning_dynamics_dataset.save_to_disk(learning_dynamics_dataset_path)
 
-    if checkpointing_config.save_checkpoint_repo_id is not None:
+    if checkpointing_config.save_to_hf:
         # Upload the HF model
         upload_folder(
             folder_path=learning_dynamics_path,
             path_in_repo=learning_dynamics_dir,
-            repo_id=checkpointing_config.save_checkpoint_repo_id,
+            repo_id=checkpointing_config.hf_checkpoint.repo_id,
             commit_message=f"Saving Learning Dynamics Data ({prefix}) -- Step {checkpoint_step}",
             revision=checkpointing_config.run_name,
             token=os.getenv("HF_TOKEN"),

--- a/src/checkpointing/training.py
+++ b/src/checkpointing/training.py
@@ -103,7 +103,7 @@ def save_checkpoint(
     optimizer: Optimizer,
     lr_scheduler: LRScheduler,
     tokenizer: PreTrainedTokenizerBase,
-    upload_logs: bool = True,
+    upload_logs: bool = False,
 ) -> None:
     """Save training checkpoint and associated states to disk and optionally to HuggingFace Hub.
 
@@ -146,7 +146,7 @@ def save_checkpoint(
         optimizer: The optimizer instance to save
         lr_scheduler: The learning rate scheduler to save
         tokenizer: The tokenizer to save
-        upload_logs: Whether to upload training logs to HF Hub (default: True)
+        upload_logs: Whether to upload training logs to HF Hub (default: False)
 
     """
 

--- a/src/config/checkpointing_config.py
+++ b/src/config/checkpointing_config.py
@@ -58,7 +58,7 @@ class LearningDynamicsCheckpointingConfig:
 @dataclass
 class HuggingFaceCheckpointingConfig:
     # Should be in the format of <(username or organization name)>/<repo_name>, e.g. pico-lm/demo
-    repo_id: Optional[str] = "pico-lm/demo"
+    repo_id: str = ""
 
     # HuggingFace Collection Slug (specifies a tag for the run)
     collection_slug: Optional[str] = None
@@ -80,7 +80,7 @@ class CheckpointingConfig:
     save_every_n_steps: int = 1000
 
     # Whether to save checkpoints to HuggingFace
-    save_to_hf: Optional[bool] = True
+    save_to_hf: Optional[bool] = False
     hf_checkpoint: HuggingFaceCheckpointingConfig = field(
         default_factory=HuggingFaceCheckpointingConfig
     )

--- a/src/config/checkpointing_config.py
+++ b/src/config/checkpointing_config.py
@@ -56,6 +56,15 @@ class LearningDynamicsCheckpointingConfig:
 
 
 @dataclass
+class HuggingFaceCheckpointingConfig:
+    # Should be in the format of <(username or organization name)>/<repo_name>, e.g. pico-lm/demo
+    repo_id: Optional[str] = "pico-lm/demo"
+
+    # HuggingFace Collection Slug (specifies a tag for the run)
+    collection_slug: Optional[str] = None
+
+
+@dataclass
 class CheckpointingConfig:
     # Name of the run
     run_name: Optional[str] = None
@@ -70,9 +79,11 @@ class CheckpointingConfig:
     # How often to save checkpoints
     save_every_n_steps: int = 1000
 
-    # Should be in the format of <(username or )>/<repo_name>, e.g. pico-lm/pico-7b
-    save_checkpoint_repo_id: Optional[str] = "pico-lm/demo"
-    hf_collection_slug: Optional[str] = None
+    # Whether to save checkpoints to HuggingFace
+    save_to_hf: Optional[bool] = True
+    hf_checkpoint: HuggingFaceCheckpointingConfig = field(
+        default_factory=HuggingFaceCheckpointingConfig
+    )
 
     training: TrainingCheckpointingConfig = field(
         default_factory=TrainingCheckpointingConfig

--- a/src/config/monitoring_config.py
+++ b/src/config/monitoring_config.py
@@ -5,7 +5,6 @@ Specifies the monitoring process, e.g. how to log metrics and keep track of trai
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
 
 
 @dataclass
@@ -16,8 +15,8 @@ class LoggingConfig:
 
 @dataclass
 class WandbConfig:
-    project: Optional[str] = "pico"
-    entity: Optional[str] = "pico-lm"
+    project: str = ""
+    entity: str = ""
 
 
 @dataclass

--- a/src/config/monitoring_config.py
+++ b/src/config/monitoring_config.py
@@ -15,15 +15,15 @@ class LoggingConfig:
 
 
 @dataclass
-class ExperimentTrackerConfig:
-    framework: Optional[str] = "wandb"
-    wandb_project: Optional[str] = "pico"
-    wandb_entity: Optional[str] = "pico-lm"
+class WandbConfig:
+    project: Optional[str] = "pico"
+    entity: Optional[str] = "pico-lm"
 
 
 @dataclass
 class MonitoringConfig:
     logging: LoggingConfig = field(default_factory=LoggingConfig)
-    experiment_tracker: ExperimentTrackerConfig = field(
-        default_factory=ExperimentTrackerConfig
-    )
+
+    # Weights and Biases
+    save_to_wandb: bool = True
+    wandb: WandbConfig = field(default_factory=WandbConfig)

--- a/src/model/pico_decoder.py
+++ b/src/model/pico_decoder.py
@@ -525,14 +525,12 @@ class PicoDecoder(nn.Module):
 
 ########################################################
 #
-# PicoConfig and PicoForHF
+# HuggingFace Wrapper
 #
 ########################################################
 
 """
 HuggingFace wrapper for the Pico model.
-
-Why do we need a wrapper? Good question!
 
 Many evaluation frameworks require a model be setup as a HuggingFace model, so we provide a simple
 wrapper that does just that. When we save checkpoints of the Pico model, we save both the normal
@@ -597,7 +595,9 @@ class PicoDecoderHF(PreTrainedModel):
         Forwards pass for the HuggingFace version of the Pico Model. Basic wrapper around the
         Pico model's forward pass, and returns the output as a HuggingFace CausalLMOutput.
         """
-        logits, past_key_values = self.pico(input_ids, past_key_values, use_cache)
+        logits, past_key_values = self.pico_decoder(
+            input_ids, past_key_values, use_cache
+        )
         if use_cache:
             return CausalLMOutputWithPast(
                 logits=logits,

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -35,7 +35,7 @@ from src.training.utils import (
     initialize_dataloader,
     initialize_lr_scheduler,
     initialize_hf_checkpointing,
-    initialize_experiment_tracker,
+    initialize_wandb,
     initialize_logging,
     initialize_optimizer,
     initialize_model,
@@ -81,15 +81,18 @@ class Trainer:
         initialize_run_dir(checkpointing_config=self.configs["checkpointing"])
 
         # Setup Logger
-        self.experiment_tracker = initialize_experiment_tracker(
-            monitoring_config=self.configs["monitoring"],
-            checkpointing_config=self.configs["checkpointing"],
-        )
+        if self.configs["monitoring"].save_to_wandb:
+            wandb_logger = initialize_wandb(
+                monitoring_config=self.configs["monitoring"],
+                checkpointing_config=self.configs["checkpointing"],
+            )
+        else:
+            wandb_logger = None
 
         # Setup Fabric
         self.fabric = initialize_fabric(
             training_config=self.configs["training"],
-            experiment_tracker=self.experiment_tracker,
+            wandb_logger=wandb_logger,
         )
         L.seed_everything(42, verbose=False)
 
@@ -113,7 +116,7 @@ class Trainer:
         self.model, self.optimizer = self.fabric.setup(self.model, self.optimizer)
 
         # Setup HuggingFace Checkpointing
-        if self.configs["checkpointing"].save_checkpoint_repo_id is not None:
+        if self.configs["checkpointing"].save_to_hf:
             initialize_hf_checkpointing(
                 checkpointing_config=self.configs["checkpointing"], fabric=self.fabric
             )

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -318,7 +318,7 @@ class Trainer:
                     fabric=self.fabric,
                     model=self.model,
                     dataset=self.learning_dynamics_eval_dataset,
-                    compute_gradients=False,
+                    compute_gradients=True,
                 )
                 save_learning_dynamics_states(
                     checkpointing_config=self.configs["checkpointing"],
@@ -544,7 +544,7 @@ class Trainer:
                             fabric=self.fabric,
                             model=self.model,
                             dataset=self.learning_dynamics_eval_dataset,
-                            compute_gradients=False,
+                            compute_gradients=True,
                         )
                         save_learning_dynamics_states(
                             checkpointing_config=self.configs["checkpointing"],

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -248,7 +248,6 @@ class Trainer:
             optimizer=self.optimizer,
             lr_scheduler=self.lr_scheduler,
             tokenizer=self.tokenizer,
-            upload_logs=False,
         )
 
         # Save Initial Evaluation Results

--- a/src/training/utils/__init__.py
+++ b/src/training/utils/__init__.py
@@ -13,7 +13,7 @@ from .initialization import (
     initialize_dataloader,
     initialize_lr_scheduler,
     initialize_hf_checkpointing,
-    initialize_experiment_tracker,
+    initialize_wandb,
     initialize_logging,
     initialize_optimizer,
     initialize_model,

--- a/src/training/utils/initialization.py
+++ b/src/training/utils/initialization.py
@@ -544,14 +544,11 @@ def initialize_wandb(
         Optional[WandbLogger]: An experiment tracker instance.
     """
 
-    if not monitoring_config.save_to_wandb:
-        return None
-
     assert (
-        monitoring_config.wandb.project is not None
+        monitoring_config.wandb.project is not None and monitoring_config.wandb.project != ""
     ), "Wandb project must be provided if wandb is to be used."
     assert (
-        monitoring_config.wandb.entity is not None
+        monitoring_config.wandb.entity is not None and monitoring_config.wandb.entity != ""
     ), "Wandb entity must be provided if wandb is to be used."
 
     _run_id = None
@@ -653,7 +650,9 @@ def initialize_hf_checkpointing(
         return
 
     huggingface_repo_id = checkpointing_config.hf_checkpoint.repo_id
-    assert huggingface_repo_id is not None, "hf_checkpoint.repo_id must be provided."
+    assert (
+        huggingface_repo_id is not None and huggingface_repo_id != ""
+    ), "hf_checkpoint.repo_id must be provided."
 
     repo = create_repo(huggingface_repo_id, exist_ok=True)
 

--- a/src/training/utils/io.py
+++ b/src/training/utils/io.py
@@ -2,7 +2,7 @@ import time
 from functools import wraps
 
 
-def use_backoff(max_retries=10, initial_delay=1, backoff_factor=2):
+def use_backoff(max_retries=2, initial_delay=1, backoff_factor=2):
     """
     Universal retry wrapper with exponential backoff for any function, but primarily for loading
     and storing HuggingFace datasets and objects.


### PR DESCRIPTION
If we look at the Pico codebase so far we've hard-coded in the assumption the pico model is an autoregressive transformer model. In the previous PR we merged, we allow people to specify a model_type and renamed the pico model to be pico_decoder to set the stage for other types of pico architectures we might want to implement later. In this PR: 
1.  I propose changing the naming convention of the saved models to reflect that these models are pico-decoder models 
2. I change the way we specify hf checkpointing and wandb saving. I think we should just simplify things and only enable wandb. For one the pico-analyze package is hard-coded for wandb, and it's really the only common solution for experiment tracking. Also I make it easier to turn off saving to hf and wandb. 
3. Minor edit but I think we shouldn't log up the logs because they don't really add much value other than for local debugging and on the HF checkpoints because we've restarted several times there are a bunch of logs that might confuse users.