### PR TITLE
Updates to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This uniformity means you can isolate model size as the primary variable, giving
 
    ```bash
    git clone https://github.com/pico-lm/pico-train
-   cd pico
+   cd pico-train
    ```
 
 2. **Configure Environment**

--- a/setup.sh
+++ b/setup.sh
@@ -115,8 +115,27 @@ print_section "Poetry Setup"
 # First check if Poetry is installed
 if ! command -v poetry &> /dev/null; then
     echo "Poetry not found. Installing..."
+    
+    # Run the installation command
     curl -sSL https://install.python-poetry.org | python3 -
-    print_success "Poetry installed successfully"
+    POETRY_INSTALL_STATUS=$?
+    
+    if [ $POETRY_INSTALL_STATUS -ne 0 ]; then
+        print_warning "Poetry installation failed!"
+        ERRORS_FOUND=$((ERRORS_FOUND + 1))
+    else
+        export PATH="$HOME/.local/bin:$PATH"
+        
+        # Verify installation succeeded
+        if ! command -v poetry &> /dev/null; then
+            print_warning "Poetry was installed but cannot be found in PATH!"
+            echo -e "${YELLOW}    Try adding this to your shell profile:${NC}"
+            echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+            ERRORS_FOUND=$((ERRORS_FOUND + 1))
+        else
+            print_success "Poetry installed successfully"
+        fi
+    fi
 else
     print_success "Poetry already installed"
 fi
@@ -125,8 +144,17 @@ fi
 if [ ! -d ".venv" ]; then
     echo "No virtual environment found. Creating one..."
     poetry config virtualenvs.in-project true
-    poetry install --with dev 
-    print_success "Poetry environment created successfully"
+    
+    # Create virtual environment and install dependencies
+    poetry install --with dev
+    POETRY_VENV_STATUS=$?
+    
+    if [ $POETRY_VENV_STATUS -ne 0 ]; then
+        print_warning "Failed to create Poetry virtual environment!"
+        ERRORS_FOUND=$((ERRORS_FOUND + 1))
+    else
+        print_success "Poetry environment created successfully"
+    fi
 else
     print_success "Poetry environment already exists"
 fi
@@ -137,12 +165,22 @@ print_section "Pre-commit Setup"
 # Install pre-commit hooks
 echo "Installing pre-commit hooks..."
 poetry run pre-commit install
-print_success "Pre-commit hooks installed"
+if [ $? -ne 0 ]; then
+    print_warning "Failed to install pre-commit hooks!"
+    ERRORS_FOUND=$((ERRORS_FOUND + 1))
+else
+    print_success "Pre-commit hooks installed"
+fi
 
 # Run pre-commit hooks on all files
 echo "Running pre-commit hooks on all files..."
 poetry run pre-commit run --all-files
-print_success "Pre-commit initial run complete"
+if [ $? -ne 0 ]; then
+    print_warning "Pre-commit encountered issues with some files"
+    ERRORS_FOUND=$((ERRORS_FOUND + 1))
+else
+    print_success "Pre-commit initial run complete"
+fi
 
 # --- Final Status Message --- #
 
@@ -150,8 +188,13 @@ print_success "Pre-commit initial run complete"
 print_section "Setup Status"
 if [ $ERRORS_FOUND -eq 0 ]; then
     print_success "Setup Complete! 🎉"
-    print_success "To activate the virtual environment, run: poetry shell"
+    print_success "To activate the virtual environment, run: poetry env activate"
 else
-    print_warning "Setup completed with warnings! Please check the messages above."
-    echo -e "${YELLOW}    Some features might not work as expected.${NC}"
+    print_warning "Setup completed with warnings and errors! Please check the messages above."
+    echo -e "${YELLOW}    ${ERRORS_FOUND} issue(s) were detected that may affect functionality.${NC}"
+    if [ -d ".venv" ]; then
+        echo -e "${YELLOW}    You can still activate the environment with: poetry env activate${NC}"
+    else
+        echo -e "${RED}    The virtual environment setup failed. Fix the issues before proceeding.${NC}"
+    fi
 fi

--- a/src/training/utils/initialization.py
+++ b/src/training/utils/initialization.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional, Union
 
 import lightning as L
 import torch
+import wandb
 import yaml
 from datasets import Dataset, DownloadConfig, load_dataset
 from datasets import config as datasets_config
@@ -26,8 +27,8 @@ from lightning.fabric.loggers import Logger as FabricLogger
 from lightning.fabric.utilities.rank_zero import rank_zero_only
 from torch.utils.data import DataLoader
 from transformers import AutoTokenizer
+from wandb.integration.lightning.fabric import WandbLogger
 
-import wandb
 from src.config import (
     CheckpointingConfig,
     DataConfig,
@@ -38,7 +39,6 @@ from src.config import (
 )
 from src.model import PicoDecoder
 from src.training.utils.io import use_backoff
-from wandb.integration.lightning.fabric import WandbLogger
 
 warnings.filterwarnings(
     "ignore",


### PR DESCRIPTION
## Summary of changes
### `README.md`
- When `pico-train` is cloned, the new directory is `pico-train`, not `pico`

### `setup.sh`
- Add poetry to path
- Add an error if any part of the poetry process fails and report
- `poetry shell` is now no longer used; changed it to recommended method.

resolves #46 